### PR TITLE
update key locations to use keys in classpath

### DIFF
--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -22,9 +22,9 @@ spring.datasource.initialization-mode: always
 sftp.host=localhost
 sftp.port=22
 sftp.user=foo
-sftp.privateKey=file://id_rsa
+sftp.privateKey=classpath:id_rsa
 sftp.privateKeyPassphrase=
-sftp.pgp.csvSecretKey=file://acceptanceTestPrivateKey.asc
+sftp.pgp.csvSecretKey=classpath:acceptanceTestPrivateKey.asc
 sftp.pgp.csvKeyPassphrase=fsdrTest
 
 rcaExtractLocation=file:${home}/Documents/sftp/


### PR DESCRIPTION
change the default location of keys used when running tests locally, keys should now be picked up from the resources folder